### PR TITLE
Ensure PDF rendering falls back to raster images when text extraction fails

### DIFF
--- a/api/app/services/render.py
+++ b/api/app/services/render.py
@@ -57,11 +57,17 @@ class DocumentRenderer:
         pages: List[RenderedPage] = []
         with pdfplumber.open(BytesIO(payload)) as pdf:  # pragma: no cover - heavy dependency
             for index, page in enumerate(pdf.pages, start=1):
-                text = page.extract_text() or ""
-                if text.strip():
+                try:
+                    text = page.extract_text()
+                except Exception:  # pragma: no cover - defensive path
+                    text = None
+
+                if isinstance(text, str) and text.strip():
                     payload_bytes = text.encode("utf-8")
                 else:
-                    payload_bytes = self._rasterize_page(page, page_number=index, source=source)
+                    payload_bytes = self._rasterize_page(
+                        page, page_number=index, source=source
+                    )
 
                 pages.append(
                     RenderedPage(

--- a/tests/fixtures/blank.pdf
+++ b/tests/fixtures/blank.pdf
@@ -1,0 +1,19 @@
+%PDF-1.1
+1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj
+2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 612 792] >>endobj
+3 0 obj<< /Type /Page /Parent 2 0 R /Resources << >> /Contents 4 0 R >>endobj
+4 0 obj<< /Length 0 >>stream
+
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000102 00000 n 
+0000000177 00000 n 
+trailer<< /Size 5 /Root 1 0 R >>
+startxref
+226
+%%EOF

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -81,3 +81,22 @@ def test_render_pdf_raises_when_pdfplumber_missing(monkeypatch):
 
     with pytest.raises(RuntimeError, match="pdfplumber is required"):
         renderer.render(b"%PDF-1.4", filename="missing.pdf")
+
+
+def test_render_pdf_without_extractable_text_returns_image_bytes():
+    pytest.importorskip("pdfplumber")
+
+    pdf_path = PROJECT_ROOT / "tests" / "fixtures" / "blank.pdf"
+    payload = pdf_path.read_bytes()
+
+    renderer = render.DocumentRenderer()
+
+    try:
+        pages = renderer.render(payload, filename="blank.pdf")
+    except RuntimeError as exc:  # pragma: no cover - dependency missing at runtime
+        pytest.skip(f"Rasterization backend unavailable: {exc}")
+
+    assert len(pages) == 1
+    page = pages[0]
+    assert page.payload, "Rasterized payload should not be empty"
+    assert page.payload.startswith(b"\x89PNG"), "Expected PNG rasterized payload"


### PR DESCRIPTION
## Summary
- fall back to rasterizing PDF pages whenever `extract_text` returns nothing or raises an error
- provide a fixture and regression test to verify non-empty raster payloads for PDFs without extractable text
- keep a clear runtime error when `pdfplumber` is unavailable so missing dependencies do not go unnoticed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e2c413901c83219634528942ec9895